### PR TITLE
fix(template-generator): fix xss problem in issue message

### DIFF
--- a/lib/template-generator.js
+++ b/lib/template-generator.js
@@ -147,7 +147,7 @@ function renderIssue(message) {
 		severityName: message.severity === 1 ? 'Warning' : 'Error',
 		lineNumber: message.line,
 		column: message.column,
-		message: message.message,
+		message: _.escape(message.message),
 		ruleId: message.ruleId,
 		ruleLink: getRuleLink(message.ruleId)
 	});
@@ -207,15 +207,6 @@ function renderResultDetails(sourceCode, messages, parentIndex) {
 }
 
 /**
- * Formats the source code before adding it to the HTML
- * @param {string} sourceCode Source code string
- * @returns {string} Source code string which will not cause issues in the HTML
- */
-function formatSourceCode(sourceCode) {
-	return sourceCode.replace(/</g, '&#60;').replace(/>/g, '&#62;');
-}
-
-/**
  * Creates the test results HTML
  * @param {Array} results Test results.
  * @param {String} currDir Current working directory
@@ -235,7 +226,7 @@ function renderResults(results, currDir) {
 		// only renders the source code if there are issues present in the file
 		if (!_.isEmpty(result.messages)) {
 			// reads the file to get the source code if the source is not provided
-			const sourceCode = formatSourceCode(result.source || fs.readFileSync(result.filePath, 'utf8'));
+			const sourceCode = _.escape(result.source || fs.readFileSync(result.filePath, 'utf8'));
 
 			template += renderResultDetails(sourceCode, result.messages, index);
 		}


### PR DESCRIPTION
- use `_.escape` for safer html escape instead of `formatSourceCode`
- escape issue message when rendering issues

e.g. rule `'vue/no-lone-template'` produces message ``'`<template>` require directive.'``