### PR TITLE
Fix assignment to constant

### DIFF
--- a/lib/helpers/scripts.html
+++ b/lib/helpers/scripts.html
@@ -27,7 +27,7 @@
 		lintResults.forEach(result => {
 			const resultText = result.getElementsByClassName("result-filepath")[0].innerText;
 
-			const includesFilter = result.className.includes(filterValue);
+			let includesFilter = result.className.includes(filterValue);
 
 			if (text && text.length > 0) {
 				includesFilter = includesFilter && resultText.toLowerCase().includes(text.toLowerCase());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-detailed-reporter",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-detailed-reporter",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Detailed HTML reporter for ESLINT.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This was causing errors in the console and breaking the search function.

```
Uncaught TypeError: Assignment to constant variable.
    at eslint-report.html:2868:20
    at NodeList.forEach (<anonymous>)
    at applyFilterAndSearch (eslint-report.html:2862:15)
    at filterResults (eslint-report.html:2904:3)
    at HTMLInputElement.onchange (eslint-report.html:420:145)
 ```