### PR TITLE
feat(template-generator.js): configure summary results by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ Setting env vars will vary based on your OS and usage. When using the ESLINT CLI
 ESLINT_DETAILED_REPORT_MAX_RULES=10 ESLINT_DETAILED_REPORT_MAX_FILES=10 eslint file.js -f node_modules/eslint-detailed-reporter/lib/detailed.js -o report.html
 ```
 
+### Configuring Details Results
+
+If you have a lot of problems, you might want to limit the number of files displayed in the Details section of the report. You can use the `ESLINT_DETAILED_REPORT_LIMIT_DETAILS` env var to only show details for your top offending files.
+
+```js
+ESLINT_DETAILED_REPORT_LIMIT_DETAILS=true eslint file.js -f node_modules/eslint-detailed-reporter/lib/detailed.js -o report.html
+```
+
+
 ## Dependencies
 
 - [lodash](https://github.com/lodash/lodash): Lodash modular utilities.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 ## Features
 
 - Total count of problems on linted files(counting both errors and warnings)
-- Tables with top 5 warnings and errors in the linted files.
-- List of top 5 files with the most problems.
+- Tables with top warnings and errors in the linted files.
+- List of top files with the most problems.
 - View of source code with issues for files with issues.
 - Summary of issues per file
 - Links to the rule descriptions for all default eslint rules, as well as angular and lodash rules.
@@ -88,6 +88,21 @@ gulp.src(['js/**/*.js'])
       fs.writeFileSync(path.join(__dirname, 'report-results.html'), results);
     })
   );
+```
+
+### Configuring Summary Results
+
+By default the report will list the top 5 offensive rules and files. You can configure the number of results you wish to display in the summary by using these environment variables. 
+
+```js
+ESLINT_DETAILED_REPORT_MAX_RULES
+ESLINT_DETAILED_REPORT_MAX_FILES
+```
+
+Setting env vars will vary based on your OS and usage. When using the ESLINT CLI for example, you could just prepend your vars.
+
+```js
+ESLINT_DETAILED_REPORT_MAX_RULES=10 ESLINT_DETAILED_REPORT_MAX_FILES=10 eslint file.js -f node_modules/eslint-detailed-reporter/lib/detailed.js -o report.html
 ```
 
 ## Dependencies

--- a/lib/template-generator.js
+++ b/lib/template-generator.js
@@ -12,6 +12,7 @@ const _ = require('lodash'),
 
 const MAX_RULES = process.env.ESLINT_DETAILED_REPORT_MAX_RULES || 5;
 const MAX_FILES = process.env.ESLINT_DETAILED_REPORT_MAX_FILES || 5;
+const LIMIT_DETAILS = process.env.ESLINT_DETAILED_REPORT_LIMIT_DETAILS === 'true' || false;
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -215,8 +216,14 @@ function renderResultDetails(sourceCode, messages, parentIndex) {
  * @param {String} currDir Current working directory
  * @returns {string} HTML string describing the results.
  */
-function renderResults(results, currDir) {
+function renderResults(results, currDir, problemFiles) {
 	return _.map(results, function(result, index) {
+		if (LIMIT_DETAILS) {
+			const isAProblemFile = problemFiles.find((file) => result.filePath === file.filePath);
+
+			if (!isAProblemFile) return '';	
+		}
+
 		let template = resultTemplate({
 			index,
 			fileId: _.camelCase(result.filePath),
@@ -369,7 +376,7 @@ module.exports.generateTemplate = function generateTemplate(results, isMultiOn) 
 		reportColor: renderColor(totalErrors, totalWarnings),
 		reportSummary: renderSummary(totalErrors, totalWarnings),
 		summaryDetails: renderSummaryDetails(rules, problemFiles, currWorkingDir),
-		results: renderResults(results, currWorkingDir),
+		results: renderResults(results, currWorkingDir, problemFiles),
 		styles: isMultiOn && isOutputDirKnown() ? '<link rel="stylesheet" href="./styles.css">' : styles(),
 		scripts: isMultiOn && isOutputDirKnown() ? '<script type="text/javascript" src="./main.js"></script>' : scripts()
 	});

--- a/lib/template-generator.js
+++ b/lib/template-generator.js
@@ -10,6 +10,9 @@ const _ = require('lodash'),
 	fs = require('fs'),
 	path = require('path');
 
+const MAX_RULES = process.env.ESLINT_DETAILED_REPORT_MAX_RULES || 5;
+const MAX_FILES = process.env.ESLINT_DETAILED_REPORT_MAX_FILES || 5;
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -246,7 +249,7 @@ function renderRules(rules) {
 			ruleCount: _.size(ruleMessages),
 			ruleLink: getRuleLink(ruleId)
 		};
-	}).orderBy(['ruleCount'], ['desc']).take(5).map(rulesTemplate).value().join('\n');
+	}).orderBy(['ruleCount'], ['desc']).take(MAX_RULES).map(rulesTemplate).value().join('\n');
 }
 
 /**
@@ -345,7 +348,7 @@ module.exports.generateTemplate = function generateTemplate(results, isMultiOn) 
 		problemFiles = _(results).reject({
 			errorCount: 0,
 			warningCount: 0
-		}).orderBy(['errorCount', 'warningCount'], ['desc', 'desc']).take(5).value(); // top five files with most problems
+		}).orderBy(['errorCount', 'warningCount'], ['desc', 'desc']).take(MAX_FILES).value(); // top five files with most problems
 
 	let totalErrors = 0,
 		totalWarnings = 0;


### PR DESCRIPTION
Allow the number of summary results to be configured with ENV vars
- ESLINT_DETAILED_REPORT_MAX_RULES
- ESLINT_DETAILED_REPORT_MAX_FILES

Allow the number of details results to be configured with ENV var
- ESLINT_DETAILED_REPORT_LIMIT_DETAILS
